### PR TITLE
Include connection when writing CACHE_KEYS

### DIFF
--- a/test/test_dalli-delete-matched.rb
+++ b/test/test_dalli-delete-matched.rb
@@ -13,7 +13,9 @@ describe "DalliDeleteMatched" do
         dc.flush
 
         store = ActiveSupport::Cache::DalliStore.new('localhost:19122')
-        store.send :write_entry, "test", "content", {}
+        store.with do |connection|
+          store.send :write_entry, "test", "content", { :connection => connection }
+        end
 
         assert_equal store.send(:get_cache_keys), ["test"]
       end


### PR DESCRIPTION
To work with the current version of dalli, the connection has to be passed in the options hash when calling (old_)write_entry. 
